### PR TITLE
refactor: update <a> tags in navbar to <Link> for SPA routing

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import Logo from "/logo.png";
 import "./Navbar.css";
+import { Link } from "react-router-dom";
 
 const Navbar: React.FC = () => {
   return (
@@ -10,13 +11,13 @@ const Navbar: React.FC = () => {
       <nav className="navbar">
         <ul>
           <li>✦</li>
-          <li><a href="/">home</a></li>
+          <li><Link to="/">home</Link></li>
           <li>✦</li>
-          <li><a href="/initiatives">initiatives</a></li>
+          <li><Link to="/initiatives">initiatives</Link></li>
           <li>✦</li>
-          <li><a href="/events">events</a></li>
+          <li><Link to="/events">events</Link></li>
           <li>✦</li>
-          <li><a href="/membership">membership</a></li>
+          <li><Link to="/membership">membership</Link></li>
           <li>✦</li>
         </ul>
       </nav>


### PR DESCRIPTION
Replaced the <a> tags in the navbar to ReactRouterDom.Link so that React's Single Page Application (SPA) functionality can work. This removes the full page reload that <a> does and feels faster to navigate.